### PR TITLE
Fix missing auth export

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,6 +1,7 @@
 
 import { initializeApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
+import { getAuth } from "firebase/auth";
 
 const firebaseConfig = {
   apiKey: "AIzaSyBmKazNVKE4dEF7bkEsbBAYhRTQp94x4fo",
@@ -14,4 +15,6 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
-export { db };
+const auth = getAuth(app);
+
+export { db, auth };


### PR DESCRIPTION
## Summary
- initialize Firebase auth module
- export `auth` along with `db`

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846973d94288326a316d0bc24497540